### PR TITLE
Day 3 : GitHub API + Test Doubles

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
     "babel-preset-env": "~1.6.0",
     "babel-register": "~6.24.1",
     "chai": "~4.1.1",
-    "mocha": "~3.5.0"
+    "mocha": "~3.5.0",
+    "sinon": "~3.1.0"
+  },
+  "dependencies": {
+    "request": "~2.81.0",
+    "request-promise": "~4.2.1"
   }
 }

--- a/src/day3.js
+++ b/src/day3.js
@@ -11,7 +11,7 @@ function day3() {
         resolveWithFullResponse: true,
         json: true,
         headers: {
-            // 'User-Agent': 'JavaScript Testing Beginners Course'
+            'User-Agent': 'JavaScript Testing Beginners Course'
         }
     };
 
@@ -24,7 +24,10 @@ function day3() {
             };
         })
         .catch((error) => {
-            console.log(error.statusCode);
+            return {
+                success: false,
+                error: 'API request is rate limited'
+            };
         });
 }
 

--- a/src/day3.js
+++ b/src/day3.js
@@ -1,0 +1,31 @@
+import requestPromise from 'request-promise';
+
+// TODO:
+// Use GitHub API to get info about project
+// Retrieve star, watch and fork count
+// Handle errors
+function day3() {
+    const gitHubRepoGetUrl = 'https://api.github.com/repos/expressjs/express';
+    const requestOptions = {
+        uri: gitHubRepoGetUrl,
+        resolveWithFullResponse: true,
+        json: true,
+        headers: {
+            // 'User-Agent': 'JavaScript Testing Beginners Course'
+        }
+    };
+
+    return requestPromise.get(requestOptions)
+        .then((data) => {
+            return {
+                forks: data.forks_count,
+                stars: data.stargazers_count,
+                watchers: data.watchers_count
+            };
+        })
+        .catch((error) => {
+            console.log(error.statusCode);
+        });
+}
+
+export default day3;

--- a/src/day3.js
+++ b/src/day3.js
@@ -25,6 +25,7 @@ function day3() {
         })
         .catch((error) => {
             return {
+                errorCode: error.statusCode,
                 success: false,
                 error: 'API request is rate limited'
             };

--- a/test/day3.test.js
+++ b/test/day3.test.js
@@ -1,0 +1,117 @@
+import {expect} from 'chai';
+import sinon from 'sinon';
+import requestPromise from 'request-promise';
+import day3 from '../src/day3';
+
+describe('day3 tests', () => {
+    describe.only('GitHub API - not unit tests - spy on API', () => {
+        let spyRequestGet;
+
+        beforeEach(() => {
+            spyRequestGet = sinon.spy(requestPromise, 'get');
+        });
+
+        afterEach(() => {
+            spyRequestGet.restore();
+        });
+
+        it('should call the expected endpoint once', () => {
+            return day3()
+                .then(() => {
+                    expect(spyRequestGet.callCount).to.equal(1);
+                });
+        });
+
+        it('should call the expected endpoint url', () => {
+            const expectedGitHubUrl = 'https://api.github.com/repos/expressjs/express';
+            return day3()
+                .then((data) => {
+                    expect(spyRequestGet.getCall(0).args[0].uri)
+                        .to.equal(expectedGitHubUrl);
+                });
+        });
+    });
+
+    describe('GitHub API - unit tests - stub API', () => {
+        let stubRequestGet;
+
+        beforeEach(() => {
+            stubRequestGet = sinon.stub(requestPromise, 'get');
+            stubRequestGet.resolves({});
+        });
+
+        afterEach(() => {
+            stubRequestGet.restore();
+        });
+
+        it('should call the expected endpoint once', () => {
+            return day3()
+                .then(() => {
+                    expect(stubRequestGet.callCount).to.equal(1);
+                });
+        });
+
+        it('should call the expected endpoint url', () => {
+            const expectedGitHubUrl = 'https://api.github.com/repos/expressjs/express';
+            return day3()
+                .then(() => {
+                    expect(stubRequestGet.getCall(0).args[0].uri)
+                        .to.equal(expectedGitHubUrl);
+                });
+        });
+
+        it('should return expected star count', () => {
+            const givenApiResponse = {
+                'stargazers_count': 100
+            };
+            stubRequestGet.resolves(givenApiResponse);
+
+            return day3()
+                .then((data) => {
+                    expect(data.stars)
+                        .to.equal(givenApiResponse.stargazers_count);
+                });
+        });
+
+        it('should return expected forks count', () => {
+            const givenApiResponse = {
+                'forks_count': 20
+            };
+            stubRequestGet.resolves(givenApiResponse);
+
+            return day3()
+                .then((data) => {
+                    expect(data.forks)
+                        .to.equal(givenApiResponse.forks_count);
+                });
+        });
+
+        it('should return expected watch count', () => {
+            const givenApiResponse = {
+                'watchers_count': 20
+            };
+            stubRequestGet.resolves(givenApiResponse);
+
+            return day3()
+                .then((data) => {
+                    expect(data.watchers)
+                        .to.equal(givenApiResponse.watchers_count);
+                });
+        });
+
+        it('should return expected error message when API is rate limited', () => {
+            const givenApiResponse = {
+                'message': 'API rate limit exceeded for xxx.xxx.xxx.xxx. (But here\'s the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)',
+                'documentation_url': 'https://developer.github.com/v3/#rate-limiting'
+            };
+            stubRequestGet.resolves(givenApiResponse);
+
+            return day3()
+                .then((data) => {
+                    expect(data.succes).to.be.false;
+                    expect(data.error)
+                        .to.equal('API request is rate limited');
+                });
+        });
+    });
+});

--- a/test/day3.test.js
+++ b/test/day3.test.js
@@ -1,10 +1,11 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
 import requestPromise from 'request-promise';
+import {StatusCodeError} from 'request-promise/errors';
 import day3 from '../src/day3';
 
 describe('day3 tests', () => {
-    describe.only('GitHub API - not unit tests - spy on API', () => {
+    describe('GitHub API - not unit tests - spy on API', () => {
         let spyRequestGet;
 
         beforeEach(() => {
@@ -104,13 +105,13 @@ describe('day3 tests', () => {
                 'message': 'API rate limit exceeded for xxx.xxx.xxx.xxx. (But here\'s the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)',
                 'documentation_url': 'https://developer.github.com/v3/#rate-limiting'
             };
-            stubRequestGet.resolves(givenApiResponse);
+            stubRequestGet.rejects(new StatusCodeError(403, givenApiResponse));
 
             return day3()
                 .then((data) => {
-                    expect(data.succes).to.be.false;
+                    expect(data.success).to.be.false;
                     expect(data.error)
-                        .to.equal('API request is rate limited');
+                        .to.deep.equal('API request is rate limited');
                 });
         });
     });

--- a/test/day3.test.js
+++ b/test/day3.test.js
@@ -110,6 +110,7 @@ describe('day3 tests', () => {
             return day3()
                 .then((data) => {
                     expect(data.success).to.be.false;
+                    expect(data.errorCode).to.equal(403);
                     expect(data.error)
                         .to.deep.equal('API request is rate limited');
                 });


### PR DESCRIPTION
* Initial installation of `sinon` and `request-promise` (with peer dependency of `request`)
* HTTP GET request of GitHub repo API
* Using spy and why you shouldn't in this case
* Using stub to fake responses for happy path
* Using stub to fake responses for unhappy path when rate limited